### PR TITLE
fix worldwide mii

### DIFF
--- a/plaza/mii_list.go
+++ b/plaza/mii_list.go
@@ -129,5 +129,7 @@ func MakeList(listType common.ListTag, miis []common.MiiWithArtisan, filename st
 
 	list.Header = header
 	list.Miis = miiPair
-	return common.Write(list, "151/"+filename)
+	common.Write(list, "151/"+filename)
+	list.Header.CountryRegion = 0
+	return common.Write(list, "0"/+filename)
 }


### PR DESCRIPTION
check mii out channel has an option to display worldwide miis rather than your region with the id being 0, RiiConnect24 made 2 copies of the list to fix it probably because the option to change the region was buried under a button that most people dont know does anything. this will do what RiiConnect24 did and create 2 copies of the list so that this option does not 404 or whatever