### PR TITLE
fix popcraft value

### DIFF
--- a/plaza/popcrafts.go
+++ b/plaza/popcrafts.go
@@ -38,7 +38,7 @@ type ExtendedArtisan struct {
 	_                  uint8
 	IsMasterMiiArtisan uint8
 	Popularity         uint8
-	_                  uint8
+	Arrow              uint8
 	CountryCode        uint16
 	_                  uint16
 	RK


### PR DESCRIPTION
theres a missing value for the arrow which is used in the ranking list for mii artisan that is not documented on the code