### PR TITLE
Add marquee reader from server

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	DatabaseName    string `xml:"databaseName"`
 	Address         string `xml:"address"`
 	AssetsPath      string `xml:"assetsPath"`
+	ServerURL	   	string `xml:"serverURL"`
 }
 
 func CheckError(err error) {

--- a/config-example.xml
+++ b/config-example.xml
@@ -12,4 +12,5 @@
 
     <!-- Everything else -->
     <assetsPath>mc-assets</assetsPath>
+    <serverURL>http://localhost:9011</serverURL>
 </Config>

--- a/first/addition.go
+++ b/first/addition.go
@@ -5,8 +5,11 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/WiiLink24/MiiContestChannel/common"
+	"io"
 	"math"
+	"net/http"
+
+	"github.com/WiiLink24/MiiContestChannel/common"
 )
 
 type Root struct {
@@ -123,7 +126,22 @@ func (l *Languages) GetLanguageFromJSON(language uint32) *Entry {
 }
 
 func MakeAddition() error {
-	marqueeText := []byte("WiiLink Mii Contest Channel!!!!")
+	var marqueeText []byte
+
+	resp, error := http.Get(common.GetConfig().ServerURL + "/assets/marquee/marquee.txt")
+	if error != nil {
+		marqueeText = []byte("WiiLink Mii Contest Channel!!!!")
+	} else {
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			marqueeText = []byte("WiiLink Mii Contest Channel!!!!")
+		} else {
+			marqueeText = body
+		}
+	}
+
 	var actual [1536]byte
 	copy(actual[:], marqueeText)
 

--- a/first/addition.go
+++ b/first/addition.go
@@ -127,16 +127,17 @@ func (l *Languages) GetLanguageFromJSON(language uint32) *Entry {
 
 func MakeAddition() error {
 	var marqueeText []byte
+	var baseText = []byte("WiiLink Mii Contest Channel!!!!")
 
 	resp, error := http.Get(common.GetConfig().ServerURL + "/assets/marquee/marquee.txt")
 	if error != nil {
-		marqueeText = []byte("WiiLink Mii Contest Channel!!!!")
+		marqueeText = baseText
 	} else {
 		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			marqueeText = []byte("WiiLink Mii Contest Channel!!!!")
+			marqueeText = baseText
 		} else {
 			marqueeText = body
 		}


### PR DESCRIPTION
Pretty simple
The MakeAddition function currently uses a default string for the marquee, meaning no possibility to edit it.
So, this PR adds a reader to change this value, by fetching a .txt file directly from the assets folder on the server.
If the fetch or the read fails, it will auto-default to the current marquee text.

See the following PR on the MCC Server for [more details](https://github.com/WiiLink24/MiiContestChannelServer/pull/9)